### PR TITLE
Add id-token permission to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You have to create an IAM role first for authenticating Bedrock API. You can use
 name: Code Review
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
According to [doc][1], to use OIDC assume role, pipeline should have id-token write permission.

[1]: https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#oidc