### PR TITLE
Use tool use to improve JSON output reliability

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -36,12 +36,11 @@ export class Bot {
 
   chat = async (
     message: string,
-    prefix?: string,
     jsonSchema?: JsonSchema
   ): Promise<[string, Ids]> => {
     let res: [string, Ids] = ['', {}]
     try {
-      res = await this.chat_(message, prefix, jsonSchema)
+      res = await this.chat_(message, jsonSchema)
       return res
     } catch (e: unknown) {
       warning(`Failed to chat: ${e}`)
@@ -51,7 +50,6 @@ export class Bot {
 
   private readonly chat_ = async (
     message: string,
-    prefix: string = '',
     jsonSchema?: JsonSchema
   ): Promise<[string, Ids]> => {
     // record timing
@@ -82,19 +80,7 @@ export class Bot {
                 text: message
               }
             ]
-          },
-          ...(prefix
-            ? [
-                {
-                  role: 'assistant' as ConversationRole,
-                  content: [
-                    {
-                      text: prefix
-                    }
-                  ]
-                }
-              ]
-            : [])
+          }
         ],
         inferenceConfig: {
           maxTokens: 4096,
@@ -161,6 +147,6 @@ export class Bot {
       parentMessageId: response?.$metadata.requestId,
       conversationId: response?.$metadata.cfId
     }
-    return [prefix + responseText, newIds]
+    return [responseText, newIds]
   }
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -32,7 +32,11 @@ export class Bot {
     this.client = new BedrockRuntimeClient({})
   }
 
-  chat = async (message: string, prefix?: string, jsonSchema?: JsonSchema): Promise<[string, Ids]> => {
+  chat = async (
+    message: string,
+    prefix?: string,
+    jsonSchema?: JsonSchema
+  ): Promise<[string, Ids]> => {
     let res: [string, Ids] = ['', {}]
     try {
       res = await this.chat_(message, prefix, jsonSchema)
@@ -57,14 +61,14 @@ export class Bot {
     let response: ConverseCommandOutput | undefined
 
     message = `IMPORTANT: Entire response must be in the language with ISO code: ${this.options.language}\n\n${message}`
-    
+
     if (this.options.debug) {
       info(`sending prompt: ${message}\n------------`)
       if (jsonSchema) {
         info(`Using JSON schema: ${JSON.stringify(jsonSchema)}`)
       }
     }
-    
+
     try {
       const commandParams: any = {
         modelId: this.bedrockOptions.model,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,7 +1,8 @@
 import {
   BedrockRuntimeClient,
   ConverseCommand,
-  ConverseCommandOutput
+  ConverseCommandOutput,
+  ToolConfiguration
 } from '@aws-sdk/client-bedrock-runtime'
 import {info, warning} from '@actions/core'
 import pRetry from 'p-retry'
@@ -11,6 +12,12 @@ import {BedrockOptions, Options} from './options'
 export interface Ids {
   parentMessageId?: string
   conversationId?: string
+}
+
+export interface JsonSchema {
+  name: string
+  description: string
+  parameters: Record<string, any>
 }
 
 export class Bot {
@@ -25,10 +32,10 @@ export class Bot {
     this.client = new BedrockRuntimeClient({})
   }
 
-  chat = async (message: string, prefix?: string): Promise<[string, Ids]> => {
+  chat = async (message: string, prefix?: string, jsonSchema?: JsonSchema): Promise<[string, Ids]> => {
     let res: [string, Ids] = ['', {}]
     try {
-      res = await this.chat_(message, prefix)
+      res = await this.chat_(message, prefix, jsonSchema)
       return res
     } catch (e: unknown) {
       warning(`Failed to chat: ${e}`)
@@ -38,7 +45,8 @@ export class Bot {
 
   private readonly chat_ = async (
     message: string,
-    prefix: string = ''
+    prefix: string = '',
+    jsonSchema?: JsonSchema
   ): Promise<[string, Ids]> => {
     // record timing
     const start = Date.now()
@@ -49,43 +57,65 @@ export class Bot {
     let response: ConverseCommandOutput | undefined
 
     message = `IMPORTANT: Entire response must be in the language with ISO code: ${this.options.language}\n\n${message}`
-    try {
-      if (this.options.debug) {
-        info(`sending prompt: ${message}\n------------`)
+    
+    if (this.options.debug) {
+      info(`sending prompt: ${message}\n------------`)
+      if (jsonSchema) {
+        info(`Using JSON schema: ${JSON.stringify(jsonSchema)}`)
       }
-      response = await pRetry(
-        () =>
-          this.client.send(
-            new ConverseCommand({
-              modelId: this.bedrockOptions.model,
-              messages: [
+    }
+    
+    try {
+      const commandParams: any = {
+        modelId: this.bedrockOptions.model,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                text: message
+              }
+            ]
+          },
+          ...(prefix
+            ? [
                 {
-                  role: 'user',
+                  role: 'assistant' as const,
                   content: [
                     {
-                      text: message
+                      text: prefix
                     }
                   ]
-                },
-                ...(prefix
-                  ? [
-                      {
-                        role: 'assistant' as const,
-                        content: [
-                          {
-                            text: prefix
-                          }
-                        ]
-                      }
-                    ]
-                  : [])
-              ],
-              inferenceConfig: {
-                maxTokens: 4096,
-                temperature: 0
+                }
+              ]
+            : [])
+        ],
+        inferenceConfig: {
+          maxTokens: 4096,
+          temperature: 0
+        }
+      }
+
+      // Add tool configuration if jsonSchema is provided
+      if (jsonSchema) {
+        const toolConfig: ToolConfiguration = {
+          tools: [
+            {
+              toolSpec: {
+                name: jsonSchema.name,
+                description: jsonSchema.description,
+                inputSchema: {
+                  json: jsonSchema.parameters
+                }
               }
-            })
-          ),
+            }
+          ]
+        }
+        commandParams.toolConfig = toolConfig
+      }
+
+      response = await pRetry(
+        () => this.client.send(new ConverseCommand(commandParams)),
         {
           retries: this.options.bedrockRetries
         }
@@ -100,7 +130,21 @@ export class Bot {
 
     let responseText = ''
     if (response?.output?.message != null) {
-      responseText = response.output?.message.content?.at(-1)?.text ?? ''
+      // Check if the response contains a tool use (JSON output)
+      const content = response.output.message.content || []
+      for (const item of content) {
+        if (item.text) {
+          responseText += item.text
+        } else if (item.toolUse) {
+          // For JSON schema tool use, the input will contain the generated JSON
+          try {
+            responseText = JSON.stringify(item.toolUse.input)
+          } catch (e) {
+            warning(`Failed to parse tool use input as JSON: ${e}`)
+            responseText = ''
+          }
+        }
+      }
     } else {
       warning('bedrock response is null')
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,7 @@
 import {
   BedrockRuntimeClient,
   ConverseCommand,
+  ConverseCommandInput,
   ConverseCommandOutput,
   ToolConfiguration
 } from '@aws-sdk/client-bedrock-runtime'
@@ -70,7 +71,7 @@ export class Bot {
     }
 
     try {
-      const commandParams: any = {
+      const commandParams: ConverseCommandInput = {
         modelId: this.bedrockOptions.model,
         messages: [
           {
@@ -84,7 +85,7 @@ export class Bot {
           ...(prefix
             ? [
                 {
-                  role: 'assistant' as const,
+                  role: 'assistant',
                   content: [
                     {
                       text: prefix

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,5 +1,6 @@
 import {
   BedrockRuntimeClient,
+  ConversationRole,
   ConverseCommand,
   ConverseCommandInput,
   ConverseCommandOutput,
@@ -75,7 +76,7 @@ export class Bot {
         modelId: this.bedrockOptions.model,
         messages: [
           {
-            role: 'user',
+            role: 'user' as ConversationRole,
             content: [
               {
                 text: message
@@ -85,7 +86,7 @@ export class Bot {
           ...(prefix
             ? [
                 {
-                  role: 'assistant',
+                  role: 'assistant' as ConversationRole,
                   content: [
                     {
                       text: prefix

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -86,15 +86,18 @@ $short_summary
 Input: New hunks annotated with line numbers and old hunks (replaced code). Hunks represent incomplete code fragments. Example input is in <example_input> tag below.
 Additional Context: <pull_request_title>, <pull_request_description>, <pull_request_changes> and comment chains. 
 Task: Review new hunks for substantive issues using provided context and respond with comments if necessary.
-Output: Review comments in markdown with exact line number ranges in new hunks. Start and end line numbers must be within the same hunk. For single-line comments, start=end line number. Must use JSON output format in <example_output> tag below.
-Use fenced code blocks using the relevant language identifier where applicable.
+
+You MUST use the JSON output tool to generate your response in the proper format. The JSON must contain:
+- An array of "reviews" with each having: line_start (integer), line_end (integer), and comment (string)
+- A boolean "lgtm" flag set to true if there are no issues found
+
+Review comments should be in markdown. Start and end line numbers must be within the same hunk. For single-line comments, use the same line number for start and end. 
+Use fenced code blocks with the relevant language identifier where applicable.
 Don't annotate code snippets with line numbers. Format and indent code correctly.
 Do not use \`suggestion\` code blocks.
 For fixes, use \`diff\` code blocks, marking changes with \`+\` or \`-\`. The line number range for comments with fix snippets must exactly match the range to replace in the new hunk.
 
 $review_file_diff
-
-If there are no issues found on a line range, you MUST respond with the flag "lgtm": true in the response JSON. Don't stop with unfinished JSON. You MUST output a complete and proper JSON that can be parsed.
 
 <example_input>
 <new_hunk>
@@ -130,24 +133,6 @@ Please review this change.
 \`\`\`
 </comment_chains>
 </example_input>
-
-<example_output>
-{
-  "reviews": [
-    {
-      "line_start": 22,
-      "line_end": 22,
-      "comment": "There's a syntax error in the add function.\\n  -    retrn z\\n  +    return z",
-    },
-    {
-      "line_start": 23,
-      "line_end": 24,
-      "comment": "There's a redundant new line here. It should be only one.",
-    }
-  ],
-  "lgtm": false
-}
-</example_output>
 
 ## Changes made to \`$filename\` for your review
 

--- a/src/review.ts
+++ b/src/review.ts
@@ -604,29 +604,29 @@ ${commentChain}
         // perform review
         try {
           const reviewJsonSchema = {
-            name: "generate_review_json",
-            description: "Generate review comments in JSON format",
+            name: 'generate_review_json',
+            description: 'Generate review comments in JSON format',
             parameters: {
-              type: "object",
+              type: 'object',
               properties: {
                 reviews: {
-                  type: "array",
+                  type: 'array',
                   items: {
-                    type: "object",
+                    type: 'object',
                     properties: {
-                      line_start: {type: "integer"},
-                      line_end: {type: "integer"},
-                      comment: {type: "string"}
+                      line_start: {type: 'integer'},
+                      line_end: {type: 'integer'},
+                      comment: {type: 'string'}
                     },
-                    required: ["line_start", "line_end", "comment"]
+                    required: ['line_start', 'line_end', 'comment']
                   }
                 },
-                lgtm: {type: "boolean"}
+                lgtm: {type: 'boolean'}
               },
-              required: ["reviews", "lgtm"]
+              required: ['reviews', 'lgtm']
             }
           }
-          
+
           const [response] = await heavyBot.chat(
             prompts.renderReviewFileDiff(ins),
             '{',
@@ -885,21 +885,21 @@ function parseReview(
   const reviews: Review[] = []
 
   try {
-    let parsedResponse;
+    let parsedResponse
     // Check if the response is already a JSON string from tool use
     try {
-      parsedResponse = JSON.parse(response);
+      parsedResponse = JSON.parse(response)
     } catch (parseErr) {
       // If it fails, try to extract JSON from the text response
-      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      const jsonMatch = response.match(/\{[\s\S]*\}/)
       if (jsonMatch) {
-        parsedResponse = JSON.parse(jsonMatch[0]);
+        parsedResponse = JSON.parse(jsonMatch[0])
       } else {
-        throw new Error('Could not extract JSON from response');
+        throw new Error('Could not extract JSON from response')
       }
     }
 
-    const rawReviews = parsedResponse.reviews || [];
+    const rawReviews = parsedResponse.reviews || []
     for (const r of rawReviews) {
       if (r.comment) {
         reviews.push({

--- a/src/review.ts
+++ b/src/review.ts
@@ -629,7 +629,6 @@ ${commentChain}
 
           const [response] = await heavyBot.chat(
             prompts.renderReviewFileDiff(ins),
-            '{',
             reviewJsonSchema
           )
           if (response === '') {

--- a/src/review.ts
+++ b/src/review.ts
@@ -603,9 +603,34 @@ ${commentChain}
       if (patchesPacked > 0) {
         // perform review
         try {
+          const reviewJsonSchema = {
+            name: "generate_review_json",
+            description: "Generate review comments in JSON format",
+            parameters: {
+              type: "object",
+              properties: {
+                reviews: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      line_start: {type: "integer"},
+                      line_end: {type: "integer"},
+                      comment: {type: "string"}
+                    },
+                    required: ["line_start", "line_end", "comment"]
+                  }
+                },
+                lgtm: {type: "boolean"}
+              },
+              required: ["reviews", "lgtm"]
+            }
+          }
+          
           const [response] = await heavyBot.chat(
             prompts.renderReviewFileDiff(ins),
-            '{'
+            '{',
+            reviewJsonSchema
           )
           if (response === '') {
             info('review: nothing obtained from bedrock')
@@ -860,7 +885,21 @@ function parseReview(
   const reviews: Review[] = []
 
   try {
-    const rawReviews = JSON.parse(response).reviews
+    let parsedResponse;
+    // Check if the response is already a JSON string from tool use
+    try {
+      parsedResponse = JSON.parse(response);
+    } catch (parseErr) {
+      // If it fails, try to extract JSON from the text response
+      const jsonMatch = response.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        parsedResponse = JSON.parse(jsonMatch[0]);
+      } else {
+        throw new Error('Could not extract JSON from response');
+      }
+    }
+
+    const rawReviews = parsedResponse.reviews || [];
     for (const r of rawReviews) {
       if (r.comment) {
         reviews.push({
@@ -871,7 +910,8 @@ function parseReview(
       }
     }
   } catch (e: any) {
-    error(e.message)
+    error(`Failed to parse review response: ${e.message}`)
+    error(`Response was: ${response}`)
     return []
   }
 


### PR DESCRIPTION
This PR implements #25 to use AWS Bedrock tool use for better JSON output reliability.

## Changes
- Added JsonSchema interface to Bot class
- Extended chat method to accept optional jsonSchema parameter
- Added tool configuration for JSON output in Bedrock Converse API
- Modified reviewFileDiff prompt to instruct the model to use the JSON tool
- Removed example_output tag from prompt as it's now handled through tool use
- Improved parseReview function to handle tool use response format

Resolves #25